### PR TITLE
Add Dockerfile and instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# Stage 1: build the application
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Stage 2: serve the app
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-db_mapping
+# db_mapping
+
+## Local Development
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+
+## Production Build
+
+Generate a production build:
+
+```bash
+npm run build
+```
+
+## Docker
+
+The application can be containerized using the provided `Dockerfile`.
+
+Build the image:
+
+```bash
+docker build -t db_mapping .
+```
+
+Run the container, exposing the app on port 8080:
+
+```bash
+docker run -p 8080:80 db_mapping
+```
+
+Then navigate to `http://localhost:8080` in your browser.


### PR DESCRIPTION
## Summary
- add `Dockerfile` for production build and static hosting via nginx
- update `README` with development and docker usage instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d3a5a4610832d94065aa2605a6029